### PR TITLE
added logic for USER_REQUIRE_INVITATION

### DIFF
--- a/example_apps/invite_app.py
+++ b/example_apps/invite_app.py
@@ -26,6 +26,7 @@ class ConfigClass(object):
     # Flask-User settings
     USER_APP_NAME        = "AppName"                # Used by email templates
     USER_ENABLE_INVITATION = True
+    USER_REQUIRE_INVITATION = True
 
 def create_app(test_config=None):                   # For automated tests
     # Setup Flask and read config from ConfigClass defined above
@@ -117,7 +118,7 @@ def create_app(test_config=None):                   # For automated tests
         else:
             return redirect(url_for('user.login'))
 
-# The Profile page requires a logged-in user
+    # The Profile page requires a logged-in user
     @app.route('/user/profiles')
     @login_required                                 # Use of @login_required decorator
     @confirm_email_required

--- a/example_apps/test_app.py
+++ b/example_apps/test_app.py
@@ -19,7 +19,7 @@ class ConfigClass(object):
     MAIL_DEFAULT_SENDER =     os.getenv('MAIL_DEFAULT_SENDER',  '"MyApp" <noreply@example.com>')
     MAIL_SERVER =             os.getenv('MAIL_SERVER',          'smtp.gmail.com')
     MAIL_PORT =           int(os.getenv('MAIL_PORT',            '465'))
-    MAIL_USE_SSL =        int(os.getenv('MAIL_USE_SSL',         True))
+    MAIL_USE_SSL =            os.getenv('MAIL_USE_SSL',         True)
 
     # Flask-User settings
     USER_APP_NAME        = "AppName"                # Used by email templates

--- a/flask_user/tests/tst_app.py
+++ b/flask_user/tests/tst_app.py
@@ -22,7 +22,7 @@ class ConfigClass(object):
     MAIL_DEFAULT_SENDER =     os.getenv('MAIL_DEFAULT_SENDER',  '"MyApp" <noreply@example.com>')
     MAIL_SERVER =             os.getenv('MAIL_SERVER',          'smtp.gmail.com')
     MAIL_PORT =           int(os.getenv('MAIL_PORT',            '465'))
-    MAIL_USE_SSL =        int(os.getenv('MAIL_USE_SSL',         True))
+    MAIL_USE_SSL =            os.getenv('MAIL_USE_SSL',         True)
 
     # Flask-User settings
     USER_APP_NAME        = "AppName"                # Used by email templates

--- a/flask_user/views.py
+++ b/flask_user/views.py
@@ -326,7 +326,14 @@ def register():
     login_form = user_manager.login_form()                      # for login_or_register.html
     register_form = user_manager.register_form(request.form)    # for register.html
 
+    # invite token used to determine validity of registeree
     invite_token = request.values.get("token")
+
+    # require invite without a token should disallow the user from registering
+    if user_manager.require_invitation and not invite_token:
+        flash("Registration is invite only", "error")
+        return redirect(url_for('user.login'))
+
     user_invite = None
     if invite_token and db_adapter.UserInvitationClass:
         user_invite = db_adapter.find_first_object(db_adapter.UserInvitationClass, token=invite_token)


### PR DESCRIPTION
When `USER_REQUIRE_INVITATION` flag is set, if the user navigates to `/user/register` they will be thrown back to `/user/login` if an `invite_token` is not present as a request variable.

I also fixed some weird python 3.4 issues for py.test
