### PR TITLE
rethrow exception, instead of catching and throwing

### DIFF
--- a/flask_user/views.py
+++ b/flask_user/views.py
@@ -433,7 +433,7 @@ def register():
                 # delete new User object if send  fails
                 db_adapter.delete_object(user)
                 db_adapter.commit()
-                raise e
+                raise
 
         # Send user_registered signal
         signals.user_registered.send(current_app._get_current_object(),
@@ -507,7 +507,7 @@ def invite():
             # delete new User object if send fails
             db_adapter.delete_object(user_invite)
             db_adapter.commit()
-            raise e
+            raise
 
         signals \
             .user_sent_invitation \


### PR DESCRIPTION
This is better, because it preserves the stack trace of the original exception, so it can save 10-15 minutes of time during debugging. 