### PR TITLE
Changed how to import signals for py3.4 support

### DIFF
--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -31,7 +31,7 @@ Subscribing to Signals
 AFTER BLINKER HAS BEEN INSTALLED, An application can receive event notifications
 by using the event signal's ``connect_via()`` decorator::
 
-    from flask.ext.user.signals import user_logged_in
+    from flask.ext.user import user_logged_in
 
     @user_logged_in.connect_via(app)
     def _after_login_hook(sender, user, **extra):

--- a/flask_user/__init__.py
+++ b/flask_user/__init__.py
@@ -23,6 +23,8 @@ from flask_login import current_user
 
 # Enable the following: from flask.ext.user import login_required, roles_required
 from .decorators import *
+# Enable the following: from flask.ext.user import user_logged_in
+from .signals import *
 
 __version__ = '0.6.1'
 


### PR DESCRIPTION
This modification attempts to solve the issue #58 by including the signals module within \__init\__.py

Now to use a Flask-User signal, simply import it from the `flask.ext.user` namespace:

    from flask.ext.user import user_logged_in, user_logged_out

    @user_logged_in.connect_via(app)
    def logged_in(sender, user, **extra):
        sender.logger.info("USER LOGGED IN")


    

