### PR TITLE
user invite signal sends form as well

### DIFF
--- a/flask_user/views.py
+++ b/flask_user/views.py
@@ -518,7 +518,8 @@ def invite():
 
         signals \
             .user_sent_invitation \
-            .send(current_app._get_current_object(), user_invite=user_invite)
+            .send(current_app._get_current_object(), user_invite=user_invite,
+                  form=invite_form)
 
         flash(_('Invitation has been sent.'), 'success')
         return redirect(next)


### PR DESCRIPTION
An end-user defined form could have additional information within the user invite functionality, passing the form along with the signal allows for post-invite model changes.