### PR TITLE
py2-py3 compatability for ensuring 16 character secret key

### DIFF
--- a/flask_user/tokens.py
+++ b/flask_user/tokens.py
@@ -13,9 +13,13 @@ class TokenManager(object):
     def setup(self, secret):
         """ Create a cypher to encrypt IDs and a signer to sign tokens."""
         # Create cypher to encrypt IDs
-        key = secret + '0123456789abcdef'  # ensure >=16 characters
-        sixteen_byte_key = key[0:16]  # get first 16 characters
-        self.cipher = AES.new(sixteen_byte_key)
+        # and ensure >=16 characters
+        precursor = b'0123456789abcdef'
+        if isinstance(secret, bytes):
+            key = secret + precursor
+        else:
+            key = secret.encode("utf-8") + precursor
+        self.cipher = AES.new(key[0:16])
 
         # Create signer to sign tokens
         self.signer = TimestampSigner(secret)


### PR DESCRIPTION
    $ python3
    >>> import os
    >>> os.urandom(24)
    >>> b'\x92\x14\xa6\xf0"<\xd6*\xba\x11p\x88^(\xd3\xb8\xca\x9e\xcfu\x1aZTD'

Using that key in Flask-User causes an error:

    File "/Users/XXX/Flask-User/flask_user/tokens.py", line 17, in setup
    key = secret + '0123456789abcdef'  # ensure >=16 characters
    TypeError: can't concat bytes to str

If you remove the `b` in the `urandom` output it works fine.  If you then switch to python 2 you get this error:

    ValueError: AES key must be either 16, 24, or 32 bytes long 

This PR type checks the `SECRET_KEY` and converts it to a bytestring if it is a unicode string.