### PR TITLE
adds proper bootstrap classes to <input>

### DIFF
--- a/flask_user/templates/flask_user/_macros.html
+++ b/flask_user/templates/flask_user/_macros.html
@@ -36,7 +36,7 @@
 {% macro render_submit_field(field, label=None, tabindex=None) -%}
     {% if not label %}{% set label=field.label.text %}{% endif %}
     {#<button type="submit" class="form-control btn btn-default btn-primary">{{label}}</button>#}
-    <input type="submit" value="{{label}}"
+    <input type="submit" class="btn btn-default btn-primary" value="{{label}}"
            {% if tabindex %}tabindex="{{ tabindex }}"{% endif %}
            >
 {%- endmacro %}


### PR DESCRIPTION
A minor tweak-- I noticed there were classes on the original <button> and re-added them to the new <input> so talos-ng (and other bootstrapped projects) carry theme colors, etc... 