### PR TITLE
Avoid server error for users without passwords.

### DIFF
--- a/flask_user/forms.py
+++ b/flask_user/forms.py
@@ -210,7 +210,7 @@ class LoginForm(Form):
             user, user_email = user_manager.find_user_by_email(self.email.data)
 
         # Handle successful authentication
-        if user and user_manager.verify_password(self.password.data, user):
+        if user and user.password and user_manager.verify_password(self.password.data, user):
             return True                         # Successful authentication
 
         # Handle unsuccessful authentication


### PR DESCRIPTION
When integrating with other authentication mechanisms (i.e. SSO),
some users may not have a populated password field.  Check for
user.password before attempting to verify_password.