### PR TITLE
Use py-bcrypt not bcrypt by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-WTF==0.9.4
 
 # Python packages
 passlib==1.6.5
-bcrypt==2.0.0
+py-bcrypt==0.4
 pycrypto==2.6.1
 speaklater==1.3
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     platforms='any',
     install_requires=[
         'passlib',
-        'bcrypt',
+        'py-bcrypt',
         'pycrypto',
         'Flask',
         'Flask-Login',


### PR DESCRIPTION
Use py-bcrypt not bcrypt by default, so as to not make flask-user depend on python development headers and a C compiler and FFI etc
