### PR TITLE
fixed deprecated "flask.ext.*" notation

### DIFF
--- a/flask_user/decorators.py
+++ b/flask_user/decorators.py
@@ -6,7 +6,7 @@
 
 from functools import wraps
 from flask import current_app
-from flask.ext.login import current_user
+from flask_login import current_user
 
 
 def _call_or_get(function_or_property):

--- a/flask_user/forms.py
+++ b/flask_user/forms.py
@@ -6,8 +6,8 @@
 
 import string
 from flask import current_app
-from flask.ext.login import current_user
-from flask.ext.wtf import Form
+from flask_login import current_user
+from flask_wtf import Form
 from wtforms import BooleanField, HiddenField, PasswordField, SubmitField, StringField
 from wtforms import validators, ValidationError
 from .translations import lazy_gettext as _


### PR DESCRIPTION
Flask uses a new naming schema for extentions. See this quote from their website:

> As of Flask 0.11, most Flask extensions have transitioned to the new naming schema. The flask.ext.foo compatibility alias is still in Flask 0.11 but is now deprecated – you should use flask_foo.
