### PR TITLE
Add customizable render function

### DIFF
--- a/flask_user/__init__.py
+++ b/flask_user/__init__.py
@@ -5,7 +5,7 @@
     :license: Simplified BSD License, see LICENSE.txt for more details."""
 
 from passlib.context import CryptContext
-from flask import Blueprint, current_app, url_for
+from flask import Blueprint, current_app, url_for, render_template
 from flask_login import LoginManager, UserMixin as LoginUserMixin, make_secure_token
 from flask_user.db_adapters import DBAdapter
 from .db_adapters import SQLAlchemyAdapter
@@ -68,6 +68,7 @@ class UserManager(object):
                 username_validator=forms.username_validator,
                 password_validator=forms.password_validator,
                 # View functions
+                render_function=render_template,
                 change_password_view_function=views.change_password,
                 change_username_view_function=views.change_username,
                 confirm_email_view_function=views.confirm_email,
@@ -109,6 +110,7 @@ class UserManager(object):
         self.username_validator = username_validator
         self.password_validator = password_validator
         # View functions
+        self.render_function = render_function
         self.change_password_view_function = change_password_view_function
         self.change_username_view_function = change_username_view_function
         self.confirm_email_view_function = confirm_email_view_function

--- a/flask_user/views.py
+++ b/flask_user/views.py
@@ -5,7 +5,7 @@
     :license: Simplified BSD License, see LICENSE.txt for more details."""
 
 from datetime import datetime
-from flask import current_app, flash, redirect, render_template, request, url_for
+from flask import current_app, flash, redirect, request, url_for
 from flask_login import current_user, login_user, logout_user
 try: # Handle Python 2.x and Python 3.x
     from urllib.parse import quote      # Python 3.x
@@ -19,6 +19,11 @@ from .translations import gettext as _
 
 def _call_or_get(function_or_property):
     return function_or_property() if callable(function_or_property) else function_or_property
+
+
+def render(*args, **kwargs):
+    user_manager = current_app.user_manager
+    return user_manager.render_function(*args, **kwargs)
 
 
 def confirm_email(token):
@@ -105,7 +110,7 @@ def change_password():
         return redirect(form.next.data)
 
     # Process GET or invalid POST
-    return render_template(user_manager.change_password_template, form=form)
+    return render(user_manager.change_password_template, form=form)
 
 @login_required
 @confirm_email_required
@@ -141,7 +146,7 @@ def change_username():
         return redirect(form.next.data)
 
     # Process GET or invalid POST
-    return render_template(user_manager.change_username_template, form=form)
+    return render(user_manager.change_username_template, form=form)
 
 @login_required
 @confirm_email_required
@@ -208,7 +213,7 @@ def forgot_password():
         return redirect(_endpoint_url(user_manager.after_forgot_password_endpoint))
 
     # Process GET or invalid POST
-    return render_template(user_manager.forgot_password_template, form=form)
+    return render(user_manager.forgot_password_template, form=form)
 
 
 def login():
@@ -257,7 +262,7 @@ def login():
             return _do_login_user(user, login_form.next.data, login_form.remember_me.data)
 
     # Process GET or invalid POST
-    return render_template(user_manager.login_template,
+    return render(user_manager.login_template,
             form=login_form,
             login_form=login_form,
             register_form=register_form)
@@ -298,7 +303,7 @@ def manage_emails():
         return redirect(url_for('user.manage_emails'))
 
     # Process GET or invalid POST request
-    return render_template(user_manager.manage_emails_template,
+    return render(user_manager.manage_emails_template,
             user_emails=user_emails,
             form=form,
             )
@@ -453,7 +458,7 @@ def register():
             return redirect(url_for('user.login')+'?next='+reg_next)  # redirect to login page
 
     # Process GET or invalid POST
-    return render_template(user_manager.register_template,
+    return render(user_manager.register_template,
             form=register_form,
             login_form=login_form,
             register_form=register_form)
@@ -517,7 +522,7 @@ def invite():
         flash(_('Invitation has been sent.'), 'success')
         return redirect(next)
 
-    return render_template(user_manager.invite_template, form=invite_form)
+    return render(user_manager.invite_template, form=invite_form)
 
 def resend_confirm_email():
     """Prompt for email and re-send email conformation email."""
@@ -540,7 +545,7 @@ def resend_confirm_email():
         return redirect(_endpoint_url(user_manager.after_resend_confirm_email_endpoint))
 
     # Process GET or invalid POST
-    return render_template(user_manager.resend_confirm_email_template, form=form)
+    return render(user_manager.resend_confirm_email_template, form=form)
 
 
 def reset_password(token):
@@ -609,7 +614,7 @@ def reset_password(token):
             return redirect(url_for('user.login')+'?next='+next)    # redirect to login page
 
     # Process GET or invalid POST
-    return render_template(user_manager.reset_password_template, form=form)
+    return render(user_manager.reset_password_template, form=form)
 
 
 def unconfirmed():
@@ -652,7 +657,7 @@ def unauthorized():
 @confirm_email_required
 def user_profile():
     user_manager = current_app.user_manager
-    return render_template(user_manager.user_profile_template)
+    return render(user_manager.user_profile_template)
 
 
 def _send_registered_email(user, user_email, require_email_confirmation=True):


### PR DESCRIPTION
#### Short:

add `render_function` attribute to `UserManager` class ;
replace `flask.render_template` with `render` function that call `user_manager.render_function` ;
### Idea

Make it avialable to customize render function.

For example, if someone use Flask-Admin library, that requires additional arguments for rendering built-in templates, he must to copy all Flask-User's view functions and replace in them `render_template` with Flask-Admin's render function. It isn't beautiful solution.

So I decited to make this pull request that makes Flask-User more customizable.
