### PR TITLE
Flask 0.11 and Python 3 compatibility fixes

### DIFF
--- a/docs/source/authorization.rst
+++ b/docs/source/authorization.rst
@@ -14,7 +14,7 @@ the user is logged in before accessing that particular page:
 
 ::
 
-    from flask.ext.user import login_required
+    from flask_user import login_required
 
     @login_required
     @route('/profile')
@@ -22,7 +22,7 @@ the user is logged in before accessing that particular page:
         # render the user profile page
 
 | Flask-User relies on Flask-Login to implement and offer the @login_required decorator along with its underlying current_user.is_authenticated() implementation.
-| See the `Flask-Login Documentation <https://flask-login.readthedocs.org/en/latest/#flask.ext.login.login_required>`_
+| See the `Flask-Login Documentation <https://flask-login.readthedocs.org/en/latest/#flask_login.login_required>`_
 
 @roles_required
 ---------------
@@ -31,7 +31,7 @@ the user is logged in and has sufficient role-based access rights that particula
 
 In the example below the current user is required to have the 'admin' role::
 
-    from flask.ext.user import roles_required
+    from flask_user import roles_required
 
     @roles_required('admin')
     @route('/admin/dashboard')
@@ -140,6 +140,3 @@ binding a User to one or more Roles.
 Up Next
 -------
 :doc:`roles_required_app`
-
-
-

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -220,7 +220,7 @@ will be stored in the corresponding User field.
 **Extra registration fields in UserProfile model**
 
 * Add extra fields to the User data model
-* Extend a custom MyRegisterForm class from the built-in flask.ext.user.forms.RegisterForm class.
+* Extend a custom MyRegisterForm class from the built-in flask_user.forms.RegisterForm class.
   See :ref:`customizingformclasses`.
 * Add extra fields to the form **using identical field names**.
 * Specify your custom registration form: ``user_manager = UserManager(db_adapter, app, register_form=MyRegisterForm)``
@@ -236,17 +236,17 @@ Form Classes
 
 Forms can be customized by sub-classing one of the following built-in Form classes::
 
-    flask.ext.user.forms.AddEmailForm
-    flask.ext.user.forms.ChangeUsernameForm
-    flask.ext.user.forms.ChangePasswordForm
-    flask.ext.user.forms.ForgotPasswordForm
-    flask.ext.user.forms.LoginForm
-    flask.ext.user.forms.RegisterForm
-    flask.ext.user.forms.ResetPasswordForm
+    flask_user.forms.AddEmailForm
+    flask_user.forms.ChangeUsernameForm
+    flask_user.forms.ChangePasswordForm
+    flask_user.forms.ForgotPasswordForm
+    flask_user.forms.LoginForm
+    flask_user.forms.RegisterForm
+    flask_user.forms.ResetPasswordForm
 
 and specifying the custom form in the call to UserManager()::
 
-    from flask.ext.user.forms import RegisterForm
+    from flask_user.forms import RegisterForm
 
     class MyRegisterForm(RegisterForm):
         first_name = StringField('First name')
@@ -457,7 +457,3 @@ These path settings are relative to the application's ``templates`` directory.
 Token Generation
 ----------------
 To be documented.
-
-
-
-

--- a/docs/source/data_models.rst
+++ b/docs/source/data_models.rst
@@ -20,7 +20,7 @@ If you'd like to store all user information in one DataModel, use the following:
 
 ::
 
-    # Define User model. Make sure to add flask.ext.user UserMixin !!!
+    # Define User model. Make sure to add flask_user UserMixin !!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
 
@@ -68,7 +68,7 @@ If you'd like to store User Authentication information separate from User inform
         def is_active(self):
           return self.is_enabled
 
-    # Define UserAuth DataModel. Make sure to add flask.ext.user UserMixin!!
+    # Define UserAuth DataModel. Make sure to add flask_user UserMixin!!
     class UserAuth(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
         user_id = db.Column(db.Integer(), db.ForeignKey('user.id', ondelete='CASCADE'))
@@ -94,7 +94,7 @@ It can be applied to both the All-in-one User DataModel and the separated User/U
 
 ::
 
-    # Define User DataModel. Make sure to add flask.ext.user UserMixin !!!
+    # Define User DataModel. Make sure to add flask_user UserMixin !!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
         ...
@@ -134,7 +134,7 @@ It can be applied to both the All-in-one User DataModel and the separated User/U
 
 ::
 
-    # Define the User DataModel. Make sure to add flask.ext.user UserMixin!!
+    # Define the User DataModel. Make sure to add flask_user UserMixin!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
         ...

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,7 +23,7 @@ Requirements
 - Flask-Mail 0.9+ or Flask-Sendmail
 - Flask-WTF 0.9+
 - passlib 1.6+
-- pycrypto 2.6+
+- pycryptodome 3.4+
 - py-bcript 0.4+        # Recommended for speed, and only if bcrypt is used to hash passwords
 
 When using the included SQLAlchemyAdapter, Flask-User requires:
@@ -42,4 +42,3 @@ Optional requirements for Internationalization:
 Up Next
 -------
 :doc:`basic_app`
-

--- a/docs/source/internationalization.rst
+++ b/docs/source/internationalization.rst
@@ -33,7 +33,7 @@ and after the application configuration has been read:
 
 ::
 
-    from flask.ext.babel import Babel
+    from flask_babel import Babel
 
     ...
 
@@ -209,4 +209,3 @@ If the code looks right, but the account management forms are not being translat
 * Check to see if the 'Flask-Babel' package has been installed (try using ``pip freeze``).
 * Check to see if the browser has been configured to prefer the language you are testing.
 * Check to see if the 'translations/' directory is in the right place.
-

--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -31,7 +31,7 @@ Subscribing to Signals
 AFTER BLINKER HAS BEEN INSTALLED, An application can receive event notifications
 by using the event signal's ``connect_via()`` decorator::
 
-    from flask.ext.user import user_logged_in
+    from flask_user import user_logged_in
 
     @user_logged_in.connect_via(app)
     def _after_login_hook(sender, user, **extra):

--- a/example_apps/basic_app.py
+++ b/example_apps/basic_app.py
@@ -27,7 +27,7 @@ class ConfigClass(object):
 
 def create_app():
     """ Flask application factory """
-    
+
     # Setup Flask app and app.config
     app = Flask(__name__)
     app.config.from_object(__name__+'.ConfigClass')
@@ -36,7 +36,7 @@ def create_app():
     db = SQLAlchemy(app)                            # Initialize Flask-SQLAlchemy
     mail = Mail(app)                                # Initialize Flask-Mail
 
-    # Define the User data model. Make sure to add flask.ext.user UserMixin !!!
+    # Define the User data model. Make sure to add flask_user UserMixin !!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
 
@@ -95,4 +95,3 @@ def create_app():
 if __name__=='__main__':
     app = create_app()
     app.run(host='0.0.0.0', port=5000, debug=True)
-

--- a/example_apps/invite_app.py
+++ b/example_apps/invite_app.py
@@ -52,7 +52,7 @@ def create_app(test_config=None):                   # For automated tests
         print('translations=',repr(translations), 'language=', repr(language))
         return language
 
-    # Define the User data model. Make sure to add flask.ext.user UserMixin !!!
+    # Define the User data model. Make sure to add flask_user UserMixin !!!
     class User(db.Model, UserMixin):
         __tablename__ = 'user'
         id = db.Column(db.Integer, primary_key=True)
@@ -148,4 +148,3 @@ def create_app(test_config=None):                   # For automated tests
 if __name__=='__main__':
     app = create_app()
     app.run(host='0.0.0.0', port=5000, debug=True)
-

--- a/example_apps/multi_email_app.py
+++ b/example_apps/multi_email_app.py
@@ -28,7 +28,7 @@ class ConfigClass(object):
 
 def create_app():
     """ Flask application factory """
-    
+
     # Setup Flask app and app.config
     app = Flask(__name__)
     app.config.from_object(__name__+'.ConfigClass')
@@ -37,7 +37,7 @@ def create_app():
     db = SQLAlchemy(app)                            # Initialize Flask-SQLAlchemy
     mail = Mail(app)                                # Initialize Flask-Mail
 
-    # Define the User data model. Make sure to add flask.ext.user UserMixin !!!
+    # Define the User data model. Make sure to add flask_user UserMixin !!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
 
@@ -110,4 +110,3 @@ def create_app():
 if __name__=='__main__':
     app = create_app()
     app.run(host='0.0.0.0', port=5000, debug=True)
-

--- a/example_apps/roles_required_app.py
+++ b/example_apps/roles_required_app.py
@@ -43,7 +43,7 @@ def create_app(test_config=None):                   # For automated tests
     mail = Mail(app)                                # Initialize Flask-Mail
     db = SQLAlchemy(app)                            # Initialize Flask-SQLAlchemy
 
-    # Define the User data model. Make sure to add flask.ext.user UserMixin!!
+    # Define the User data model. Make sure to add flask_user UserMixin!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
 

--- a/example_apps/test_app.py
+++ b/example_apps/test_app.py
@@ -54,7 +54,7 @@ def create_app(test_config=None):                   # For automated tests
         language = request.accept_languages.best_match(translations)
         return language
 
-    # Define the User data model. Make sure to add flask.ext.user UserMixin !!!
+    # Define the User data model. Make sure to add flask_user UserMixin !!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
 

--- a/example_apps/user_auth_app.py
+++ b/example_apps/user_auth_app.py
@@ -43,7 +43,7 @@ def create_app(test_config=None):                   # For automated tests
     mail = Mail(app)                                # Initialize Flask-Mail
     db = SQLAlchemy(app)                            # Initialize Flask-SQLAlchemy
 
-    # Define the User data model. Make sure to add flask.ext.user UserMixin!!
+    # Define the User data model. Make sure to add flask_user UserMixin!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
 

--- a/example_apps/user_profile_app.py
+++ b/example_apps/user_profile_app.py
@@ -43,7 +43,7 @@ def create_app(test_config=None):                   # For automated tests
     mail = Mail(app)                                # Initialize Flask-Mail
     db = SQLAlchemy(app)                            # Initialize Flask-SQLAlchemy
 
-    # Define User model. Make sure to add flask.ext.user UserMixin!!
+    # Define User model. Make sure to add flask_user UserMixin!!
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
         user_profile_id = db.Column(db.Integer(), db.ForeignKey('user_profile.id', ondelete='CASCADE'))

--- a/flask_user/__init__.py
+++ b/flask_user/__init__.py
@@ -19,12 +19,12 @@ from . import views
 from . import signals
 from .translations import get_translations
 
-# Enable the following: from flask.ext.user import current_user
+# Enable the following: from flask_user import current_user
 from flask_login import current_user
 
-# Enable the following: from flask.ext.user import login_required, roles_required
+# Enable the following: from flask_user import login_required, roles_required
 from .decorators import *
-# Enable the following: from flask.ext.user import user_logged_in
+# Enable the following: from flask_user import user_logged_in
 from .signals import *
 
 

--- a/flask_user/decorators.py
+++ b/flask_user/decorators.py
@@ -6,7 +6,7 @@
 
 from functools import wraps
 from flask import current_app
-from flask.ext.login import current_user
+from flask_login import current_user
 
 
 def _call_or_get(function_or_property):

--- a/flask_user/forms.py
+++ b/flask_user/forms.py
@@ -6,8 +6,8 @@
 
 import string
 from flask import current_app
-from flask.ext.login import current_user
-from flask.ext.wtf import Form
+from flask_login import current_user
+from flask_wtf import Form
 from wtforms import BooleanField, HiddenField, PasswordField, SubmitField, StringField
 from wtforms import validators, ValidationError
 from .translations import lazy_gettext as _

--- a/flask_user/tests/tst_app.py
+++ b/flask_user/tests/tst_app.py
@@ -1,18 +1,18 @@
 import os
 import datetime
 from flask import Flask, render_template_string, request
-from flask.ext.babel import Babel
-from flask.ext.mail import Mail
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.user import login_required, SQLAlchemyAdapter, UserManager, UserMixin
-from flask.ext.user import roles_required, confirm_email_required
+from flask_babel import Babel
+from flask_mail import Mail
+from flask_sqlalchemy import SQLAlchemy
+from flask_user import login_required, SQLAlchemyAdapter, UserManager, UserMixin
+from flask_user import roles_required, confirm_email_required
 
 
 app = Flask(__name__)
 db = SQLAlchemy(app)                            # Initialize Flask-SQLAlchemy
 
 
-# Define the User data model. Make sure to add flask.ext.user UserMixin!!
+# Define the User data model. Make sure to add flask_user UserMixin!!
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
 

--- a/flask_user/tokens.py
+++ b/flask_user/tokens.py
@@ -19,7 +19,7 @@ class TokenManager(object):
             key = secret + precursor
         else:
             key = secret.encode("utf-8") + precursor
-        self.cipher = AES.new(key[0:16])
+        self.cipher = AES.new(key[0:16], AES.MODE_ECB)
 
         # Create signer to sign tokens
         self.signer = TimestampSigner(secret)

--- a/flask_user/tokens.py
+++ b/flask_user/tokens.py
@@ -26,7 +26,7 @@ class TokenManager(object):
 
     def encrypt_id(self, id):
         """ Encrypts integer ID to url-safe base64 string."""
-        str1 = '%016d' % id                             # --> 16 byte integer string
+        str1 = b'%016d' % id                            # --> 16 byte integer string
         str2 = self.cipher.encrypt(str1)                # --> encrypted data
         str3 = base64.urlsafe_b64encode(str2)           # --> URL safe base64 string with '=='
         return str3[0:-2]                               # --> base64 string without '=='

--- a/flask_user/translations.py
+++ b/flask_user/translations.py
@@ -27,7 +27,7 @@ def get_translations():
     # Prepare search properties
     import os
     import gettext as python_gettext
-    from flask.ext.babel import get_locale, support
+    from flask_babel import get_locale, support, get_translations as babel_gt
     domain = 'flask_user'
     locales = [get_locale()]
     languages = [str(locale) for locale in locales]
@@ -43,8 +43,7 @@ def get_translations():
         flask_user_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'translations')
         ctx.flask_user_translations = support.Translations.load(flask_user_dir, locales, domain=domain)
 
-    from flask.ext import babel
-    return ctx.flask_user_translations.merge(babel.get_translations())
+    return ctx.flask_user_translations.merge(babel_gt())
 
 def gettext(string, **variables):
     """ Translate specified string."""

--- a/misc/approved_extension.txt
+++ b/misc/approved_extension.txt
@@ -32,7 +32,7 @@ Request for Flask Extension Approval
 
     setup.py:
         install_requires=[
-            'passlib', 'bcrypt', 'pycrypto',
+            'passlib', 'bcrypt', 'pycryptodome>=3.4',
             'Flask', 'Flask-Babel', 'Flask-Login', 'Flask-Mail',
             'Flask-SQLAlchemy', 'Flask-WTF'],
 
@@ -55,4 +55,3 @@ Request for Flask Extension Approval
 10. An extension currently has to support Python 2.6 as well as Python 2.7
 
     Flask-Utils runs on Python 2.6, 2.7 and 3.3
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ Flask-WTF==0.9.4
 # Python packages
 passlib==1.6.5
 bcrypt==2.0.0
-pycrypto==2.6.1
+pycryptodome>=3.4
 speaklater==1.3
-

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ Flask-WTF==0.9.4
 # Python packages
 passlib==1.6.5
 bcrypt==2.0.0
-pycrypto==2.6.1
+pycryptodome>=3.4
 speaklater==1.3
 
 # Development packages

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     install_requires=[
         'passlib',
         'bcrypt',
-        'pycrypto',
+        'pycryptodome>=3.4',
         'Flask',
         'Flask-Login',
         'Flask-Mail',


### PR DESCRIPTION
Pycrypto is no longer being maintained, but Pycryptodome is a drop-in replacement that has better Python 3 support. Additionally, Python 3 requires strings that will be encrypted to be explicitly defined as bytestrings (they're unicode text by default) or crypto will raise an error.

Also, `flask.ext` imports were deprecated in Flask 0.11, so I replaced them with `flask_ext` (which also works in 0.10).
