### PR TITLE
Remove make_secure_token.

### DIFF
--- a/flask_user/__init__.py
+++ b/flask_user/__init__.py
@@ -6,7 +6,7 @@
 
 from passlib.context import CryptContext
 from flask import Blueprint, current_app, url_for
-from flask_login import LoginManager, UserMixin as LoginUserMixin, make_secure_token
+from flask_login import LoginManager, UserMixin as LoginUserMixin
 from flask_user.db_adapters import DBAdapter
 from .db_adapters import SQLAlchemyAdapter
 from . import emails


### PR DESCRIPTION
I get this error when import flask_user:

```
Traceback (most recent call last):
  File "app.py", line 4, in <module>
    from flask_user import UserManager, SQLAlchemyAdapter, login_required
  File "/home/mostafa/source/dt/venv/lib/python3.5/site-packages/flask_user/__init__.py", line 9, in <module>
    from flask_login import LoginManager, UserMixin as LoginUserMixin, make_secure_token
ImportError: cannot import name 'make_secure_token'
```

make_secure_token is now removed from flask-login, and it's not really
used in flask-user, just imported. I just removed the import.
