### PR TITLE
Use pycryptodome in development

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ Flask-WTF==0.9.4
 # Python packages
 passlib==1.6.5
 bcrypt==2.0.0
-pycrypto==2.6.1
+pycryptodome==3.4.3
 speaklater==1.3
 
 # Development packages

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,18 +1,2 @@
-# Flask
-Flask==0.10.1
-
-# Flask extensions
-Flask-Babel==0.9
-Flask-Login==0.2.9
-Flask-Mail==0.9.0
-Flask-SQLAlchemy==1.0
-Flask-WTF==0.9.4
-
-# Python packages
-passlib==1.6.5
-bcrypt==2.0.0
-pycryptodome==3.4.3
-speaklater==1.3
-
-# Development packages
+-r requirements.txt
 pytest==2.6.4


### PR DESCRIPTION
The use of pycryptodome comes from  #148 and `requirements_dev.txt` was not updated.  This pull request fixes that by mirroring `requirements.txt`.