### PR TITLE
fix deprecated import

### DIFF
--- a/flask_user/translations.py
+++ b/flask_user/translations.py
@@ -27,7 +27,7 @@ def get_translations():
     # Prepare search properties
     import os
     import gettext as python_gettext
-    from flask_babel import get_locale, support
+    from flask_babel import get_locale, get_translations, support
     domain = 'flask_user'
     locales = [get_locale()]
     languages = [str(locale) for locale in locales]
@@ -43,8 +43,7 @@ def get_translations():
         flask_user_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'translations')
         ctx.flask_user_translations = support.Translations.load(flask_user_dir, locales, domain=domain)
 
-    from flask.ext import babel
-    return ctx.flask_user_translations.merge(babel.get_translations())
+    return ctx.flask_user_translations.merge(get_translations())
 
 def gettext(string, **variables):
     """ Translate specified string."""

--- a/flask_user/translations.py
+++ b/flask_user/translations.py
@@ -14,7 +14,7 @@ def get_translations():
     if not ctx:
         return None
 
-    # If context exists and contains a cashed value, return cached value
+    # If context exists and contains a cached value, return cached value
     if hasattr(ctx, 'flask_user_translations'):
         return ctx.flask_user_translations
 
@@ -67,7 +67,7 @@ def lazy_gettext(string, **variables):
         from speaklater import make_lazy_string
         return make_lazy_string(gettext, string, **variables)
     except ImportError:
-       return string % variables
+        return string % variables
 
 _ = lazy_gettext
 _home_page = _('Home Page')


### PR DESCRIPTION
I get this message when using flask-user:
```
.../venv/lib/python3.5/site-packages/flask_user/translations.py:46: 
ExtDeprecationWarning: Importing flask.ext.babel is deprecated, use flask_babel instead.
  from flask.ext import babel
```