### PR TITLE
Fix example code for CustomUserManager.customize

### DIFF
--- a/docs/source/porting_customizations.rst
+++ b/docs/source/porting_customizations.rst
@@ -41,8 +41,8 @@ In v1.0, Flask-User is customized by:
 
         def customize(self, app):
             # Override properties
-            register_form = CustomRegisterForm()
-            token_manager = CustomTokenManager(app)
+            self.register_form = CustomRegisterForm
+            self.token_manager = CustomTokenManager(app)
 
         # Override methods
         def register_view(self):


### PR DESCRIPTION
* Really assign properties (`self.x` instead of `x`)
* Use class `CustomRegisterForm`, not instance

That makes the example consistent with what can be read on the following
page of documentation:
https://flask-user.readthedocs.io/en/latest/customizing_forms.html#customizing-form-classes