### PR TITLE
Fix check in template password_changed_message.txt

### DIFF
--- a/flask_user/templates/flask_user/emails/password_changed_message.txt
+++ b/flask_user/templates/flask_user/emails/password_changed_message.txt
@@ -3,10 +3,8 @@
 {% block message %}
 Your password has been changed.
 
-{% if user_manager.enable_forgot_password -%}
+{% if user_manager.USER_ENABLE_FORGOT_PASSWORD -%}
 If you did not initiate this password change, click the link below to reset it.
     {{ url_for('user.forgot_password', _external=True) }}
 {% endif -%}
 {% endblock %}
-
-


### PR DESCRIPTION
This was not the name of the setting, so the link would never appear in the text version of the email.