### PR TITLE
Change deprecated `passlib.context.CryptoContext.encrypt` to `hash` in `password_manager.py`

### DIFF
--- a/flask_user/password_manager.py
+++ b/flask_user/password_manager.py
@@ -47,7 +47,7 @@ class PasswordManager(object):
         """
 
         # Use passlib's CryptContext to hash a password
-        password_hash = self.password_crypt_context.encrypt(password)
+        password_hash = self.password_crypt_context.hash(password)
 
         return password_hash
 


### PR DESCRIPTION
Fix for warning message:

`
flask_user/password_manager.py:50: DeprecationWarning: the method passlib.context.CryptContext.encrypt() is deprecated as of Passlib 1.7, and will be removed in Passlib 2.0, use CryptContext.hash() instead.
`

As `encrypt` is [deprecated](https://bitbucket.org/ecollins/passlib/commits/1f7421b35b750a8f47cb0a8a2e208a839feb5e4f)