### PR TITLE
Added send email check when changing usernames

### DIFF
--- a/flask_user/user_manager__views.py
+++ b/flask_user/user_manager__views.py
@@ -138,7 +138,8 @@ class UserManager__Views(object):
             self.db_manager.commit()
 
             # Send username_changed email
-            self.email_manager.send_username_changed_email(current_user)
+            if self.USER_ENABLE_EMAIL and self.USER_SEND_USERNAME_CHANGED_EMAIL:
+                self.email_manager.send_username_changed_email(current_user)
 
             # Send changed_username signal
             signals.user_changed_username.send(current_app._get_current_object(), user=current_user)


### PR DESCRIPTION
Fix for error produced when changing usernames with the USER_ENABLE_EMAIL flag set to False

```
[2019-07-11 10:34:59,531] ERROR in app: Exception on /user/change-username [POST]
Traceback (most recent call last):
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask/app.py", line 2311, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask/app.py", line 1834, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask/app.py", line 1737, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask/_compat.py", line 36, in reraise
    raise value
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask/app.py", line 1832, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask/app.py", line 1818, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask_user/user_manager.py", line 390, in change_username_stub
    return self.change_username_view()
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask_user/decorators.py", line 58, in decorator
    return view_function(*args, **kwargs)
  File "/home/ubuntu/github/my_app/venv/lib/python3.5/site-packages/flask_user/user_manager__views.py", line 141, in change_username_view
    self.email_manager.send_username_changed_email(current_user)
AttributeError: 'UserManager' object has no attribute 'email_manager'
```