### PR TITLE
Fix typo in README and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Additional features
 
 Minimal Requirements
 --------------------
-- brypt 2.0+
+- bcrypt 2.0+
 - cryptography 1.6+
 - Flask 0.9+
 - Flask-Login 0.2+

--- a/docs/source/includes/main_page.rst
+++ b/docs/source/includes/main_page.rst
@@ -43,7 +43,7 @@ Additional features
 
 Minimal Requirements
 --------------------
-- brypt 2.0+
+- bcrypt 2.0+
 - cryptography 1.6+
 - Flask 0.9+
 - Flask-Login 0.2+


### PR DESCRIPTION
"bcrypt" was misspelled as "brypt"