### PR TITLE
docs: Fix simple typo, appliation -> application

### DIFF
--- a/flask_user/db_adapters/mongo_db_adapter.py
+++ b/flask_user/db_adapters/mongo_db_adapter.py
@@ -18,7 +18,7 @@ class MongoDbAdapter(DbAdapterInterface):
 
     def __init__(self, app, db):
         """Args:
-            app(Flask): The Flask appliation instance.
+            app(Flask): The Flask application instance.
             db(MongoEngine): The MongoEngine object-database mapper instance.
 
         | Example:

--- a/flask_user/db_adapters/sql_db_adapter.py
+++ b/flask_user/db_adapters/sql_db_adapter.py
@@ -20,7 +20,7 @@ class SQLDbAdapter(DbAdapterInterface):
 
     def __init__(self, app, db):
         """Args:
-            app(Flask): The Flask appliation instance.
+            app(Flask): The Flask application instance.
             db(SQLAlchemy): The SQLAlchemy object-database mapper instance.
 
         | Example:


### PR DESCRIPTION
There is a small typo in flask_user/db_adapters/mongo_db_adapter.py, flask_user/db_adapters/sql_db_adapter.py.

Should read `application` rather than `appliation`.

