### PR TITLE
refactor(package): enabling postopend init_app for all managers

### DIFF
--- a/flask_user/password_manager.py
+++ b/flask_user/password_manager.py
@@ -26,14 +26,19 @@ class PasswordManager(object):
             ``password_manager = PasswordManager('bcrypt')``
         """
 
-        self.app = app
-        self.user_manager = app.user_manager
-
         # Create a passlib CryptContext
+        self.app = app
+        self.user_manager = None
+        if app:
+            self.init_app(app)
+
         self.password_crypt_context = CryptContext(
             schemes=self.user_manager.USER_PASSLIB_CRYPTCONTEXT_SCHEMES,
             **self.user_manager.USER_PASSLIB_CRYPTCONTEXT_KEYWORDS)
 
+    def init_app(self, app):
+        self.app = app
+        self.user_manager = app.user_manager
 
     def hash_password(self, password):
         """Hash plaintext ``password`` using the ``password_hash`` specified in the constructor.

--- a/flask_user/token_manager.py
+++ b/flask_user/token_manager.py
@@ -26,7 +26,7 @@ class TokenManager(object):
 
     # *** Public methods ***
 
-    def __init__(self, app):
+    def __init__(self, app=None):
         """Check config settings and initialize the Fernet encryption cypher.
 
         Fernet is basically AES128 in CBC mode, with a timestamp and a signature.
@@ -34,7 +34,11 @@ class TokenManager(object):
         Args:
             app(Flask): The Flask application instance.
         """
+        self.app = app
+        if app:
+            self.init_app(app)
 
+    def init_app(self, app):
         self.app = app
 
         # Use the applications's SECRET_KEY if flask_secret_key is not specified.


### PR DESCRIPTION
While working on some projects, I've found out that Flask-User doesn't properly hold initialization without passed `app`, `db` and `UserClass` objects. And even if you want to firstly create `UserManager` and then `init_app`, you have to do smth like `UserManager(app=None, ...)`, which looks inconsistent and odd.