### PR TITLE
Proposed fix for CVE-2021-23401

### DIFF
--- a/flask_user/user_manager__utils.py
+++ b/flask_user/user_manager__utils.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     from urlparse import urlsplit, urlunsplit       # Python 2
 
-
 from flask_login import current_user
 
 
@@ -68,6 +67,7 @@ class UserManager__Utils(object):
         # Clear scheme and netloc and rebuild URL
         parts[0] = ''   # Empty scheme
         parts[1] = ''   # Empty netloc (hostname:port)
+        parts[2] = '/'+parts[2].lstrip('/\\')
         safe_url = urlunsplit(parts)
         return safe_url
 


### PR DESCRIPTION
This change modifies potentially malicious URLs with leading slashes and backslashes to ones with only a single slash, forcing them to be relative URLs.

URLs with consecutive slashes in the middle of the path are not affected.

Vulnerability details: https://security.snyk.io/vuln/SNYK-PYTHON-FLASKUSER-1293188
Description of URL Confusion Vulnerabilities https://snyk.io/blog/url-confusion-vulnerabilities/